### PR TITLE
Small French typo fix in Game Scanner messages

### DIFF
--- a/Celeste_Launcher_Gui/Properties/Resources.fr-FR.resx
+++ b/Celeste_Launcher_Gui/Properties/Resources.fr-FR.resx
@@ -485,7 +485,7 @@ Age of Empires Online - Celeste Fan Project</value>
     <value>Démarrage du téléchargement</value>
   </data>
   <data name="GameScannerExtracting" xml:space="preserve">
-    <value>Exctraction du fichier téléchargé</value>
+    <value>Extraction du fichier téléchargé</value>
   </data>
   <data name="GameScannerFailed" xml:space="preserve">
     <value>Une erreur inattendue s'est produite lors du scan du jeu. Veuillez réessayer ou lire les fichiers journaux.</value>


### PR DESCRIPTION
# Description

I'm currently fixing a few (?) typos present in the original AoEO French language files and i've noticed there's one in the Project Celeste Game Scanner (file extraction message), so i'm fixing it while i'm at it.

I'm aware launcher updates are few and far between and that this tiny fix absolutely doesn't justify a new version number, but this typo sticks like a sore thumb in a translation that's otherwise pretty well done and accurate, so i'm PRing it anyway.

Feel free to close if considered OCD-triggered, no offence will, of course, be taken 😁 

Anyway, thanks for your work in keeping alive a game we've fond memories of.

## Type of change

- [X] Typo fix (non-breaking change which fixes a typo)