### PR TITLE
Fix Launcher Updater when using Steam

### DIFF
--- a/Celeste_Launcher_Gui/Services/UpdateService.cs
+++ b/Celeste_Launcher_Gui/Services/UpdateService.cs
@@ -154,13 +154,6 @@ namespace Celeste_Launcher_Gui.Services
                 Misc.CleanUpFiles(tempDir, "*.*");
             }
 
-            //isSteam Version
-            if (isSteam)
-            {
-                progress?.Report(95);
-                Steam.ConvertToSteam(destinationDir);
-            }
-
             //Clean Old File
             progress?.Report(97);
             Misc.CleanUpFiles(Directory.GetCurrentDirectory(), "*.old");

--- a/Celeste_Launcher_Gui/Windows/UpdateWindow.xaml.cs
+++ b/Celeste_Launcher_Gui/Windows/UpdateWindow.xaml.cs
@@ -4,6 +4,7 @@ using Celeste_Public_Api.Logging;
 using Serilog;
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Windows;
@@ -69,6 +70,13 @@ namespace Celeste_Launcher_Gui.Windows
                 await UpdateService.DownloadAndInstallUpdate(LegacyBootstrapper.UserConfig.IsSteamVersion, progress, _cts.Token);
 
                 GenericMessageDialog.Show(Properties.Resources.LauncherUpdaterUpdateSuccess, DialogIcon.Warning, DialogOptions.Ok);
+
+                //Steam Version
+                if (LegacyBootstrapper.UserConfig.IsSteamVersion)
+                {
+                    Process.Start(Directory.GetCurrentDirectory() + "\\SteamConverter.exe", "update");
+                    Environment.Exit(0);
+                }
 
                 Process.Start(Assembly.GetEntryAssembly().Location);
 

--- a/SteamConverter/App.xaml.cs
+++ b/SteamConverter/App.xaml.cs
@@ -17,9 +17,8 @@ namespace SteamConverter
         {
             LegacyBootstrapper.LoadUserConfig();
             LegacyBootstrapper.SetUILanguage();
-            if (e.Args.Length > 0)
+            if (e.Args.Contains("update"))
             {
-                if (e.Args.Contains("update"))
                 {
                     Thread.Sleep(2500); // Wait for the updater to exit and Steam to notice it's closed
                     Steam.ConvertToSteam(LegacyBootstrapper.UserConfig.GameFilesPath);

--- a/SteamConverter/App.xaml.cs
+++ b/SteamConverter/App.xaml.cs
@@ -1,7 +1,10 @@
 ﻿using Celeste_Launcher_Gui;
 using Celeste_Launcher_Gui.Helpers;
 using Celeste_Launcher_Gui.Windows;
+using System.Linq;
 using System.Windows;
+using System.Diagnostics;
+using System.Threading;
 
 namespace SteamConverter
 {
@@ -14,6 +17,17 @@ namespace SteamConverter
         {
             LegacyBootstrapper.LoadUserConfig();
             LegacyBootstrapper.SetUILanguage();
+            if (e.Args.Length > 0)
+            {
+                if (e.Args.Contains("update"))
+                {
+                    Thread.Sleep(2500); // Wait for the updater to exit and Steam to notice it's closed
+                    Steam.ConvertToSteam(LegacyBootstrapper.UserConfig.GameFilesPath);
+                    Process.Start("steam://rungameid/105430"); //Run from Steam itself
+                    Current.Shutdown();
+                }
+            }
+
             Steam.ConvertToSteam(LegacyBootstrapper.UserConfig.GameFilesPath);
 
             var dialog = new GenericMessageDialog(Celeste_Launcher_Gui.Properties.Resources.SteamConverterSuccess, DialogIcon.None, DialogOptions.Ok);


### PR DESCRIPTION
Added new "update" argument to SteamConverter.exe

Removed converting to Steam from the updater since the internal code only works if you're using it from Celeste Launcher.exe and not AOEOnline.exe (Steam). Instead, as the updater completes, it will run SteamConverter.exe with the update argument which will wait for 2.5 seconds for the Launcher to close and give time for Steam to recognize it is closed, then convert without a dialog and relaunch from Steam.

Fixes Issue #108 